### PR TITLE
追加

### DIFF
--- a/src/main/java/whiless/onlycolor_move/config/TeamColorConfig.java
+++ b/src/main/java/whiless/onlycolor_move/config/TeamColorConfig.java
@@ -1,4 +1,48 @@
 package whiless.onlycolor_move.config;
 
-public class TeamColorConfig {
+import org.bukkit.Material;
+import org.bukkit.plugin.Plugin;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public final class TeamColorConfig extends ConfigFile {
+    public TeamColorConfig(Plugin plugin) {
+        super(plugin, "team-color-config.yml");
+
+        saveDefaultConfig();
+        getConfig().options().copyDefaults(true);
+        saveConfig();
+
+        if (!checkConsistency()) plugin.getLogger().warning("team-color-config.yml is illegal format. Please check example of default config.");
+    }
+
+    public Material getTeamMaterial(@Nonnull String team) {
+        return Material.valueOf(getConfig().getString(team));
+    }
+
+    public Material getTeamMaterial(@Nonnull String name, @Nonnull Material material) {
+        return Material.valueOf(getConfig().getString(name, material.name()));
+    }
+
+    public void setTeamMaterial(@Nonnull String team, @Nonnull Material material) {
+        getConfig().set(team, material.name());
+        saveConfig();
+    }
+
+    public Set<String> getTeams() {
+        return getConfig().getKeys(false);
+    }
+
+    private boolean checkConsistency() {
+        for (String key : getTeams()) {
+            try {
+                Material.valueOf(getConfig().getString(key));
+            } catch (Exception e) {
+                e.printStackTrace();
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
説明 & 例は下記へ
```java
import org.bukkit.Material;
import org.bukkit.plugin.java.JavaPlugin;
import whiless.onlycolor_move.config.TeamColorConfig;

public final class ExamplePlugin extends JavaPlugin {
    
    @Override
    public void onEnable() {
        final TeamColorConfig config = new TeamColorConfig(this);

        // チームリストの取得
        config.getTeams();

        // チームのMaterialを取得
        config.getTeamMaterial("team-name");

        // チームのMaterialを取得、チームがconfig上に存在しなければGRASS_BLOCKを返す
        config.getTeamMaterial("team-name", Material.GRASS_BLOCK);

        // チームのMaterialをGRASS_BLOCKとして保存
        config.setTeamMaterial("team-name", Material.GRASS_BLOCK);
    }
}
```